### PR TITLE
fix: ensure build script is run on git install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/vuexok.js",
   "types": "dist/vuexok.d.ts",
   "scripts": {
+    "prepare": "npm run build",
     "test": "eslint -c test/types/.eslintrc.json test/types/**/*.ts",
     "build": "rollup -c ./rollup.config.ts",
     "docs:dev": "vuepress dev vuepress",


### PR DESCRIPTION
This ensures the dist directory and all the built files exist when installing via git.